### PR TITLE
user.status: add 'includeSources'

### DIFF
--- a/codeforces_api/api_requests.py
+++ b/codeforces_api/api_requests.py
@@ -366,7 +366,7 @@ class CodeforcesApi(CodeforcesApiRequestMaker):
             )
         ]
 
-    def user_status(self, handle, start=-1, count=-1):
+    def user_status(self, handle, start=-1, count=-1, include_sources=False):
         """
         Get user.status.
 
@@ -375,6 +375,8 @@ class CodeforcesApi(CodeforcesApiRequestMaker):
         From was replaced with a start because from is reserved python word.
 
         count is the number of attempts to return.
+
+        include_sources is used to include sources in the response, must be your own handle.
 
         Returns parsed response from codeforces.com.
         """
@@ -385,6 +387,8 @@ class CodeforcesApi(CodeforcesApiRequestMaker):
             parameters["from"] = str(start)
         if count != -1:
             parameters["count"] = str(count)
+        if include_sources:
+            parameters["includeSources"] = "true"
         return [
             Submission.de_json(submission)
             for submission in self._make_request("user.status", **parameters)

--- a/codeforces_api/types.py
+++ b/codeforces_api/types.py
@@ -17,7 +17,7 @@ Source of inspiration: https://github.com/eternnoir/pyTelegramBotAPI/blob/master
 """
 
 import json
-
+import base64
 
 class Dictionaryable(object):
     """
@@ -661,6 +661,7 @@ class Submission(JSONDeserializable, Dictionaryable):
         contest_id = obj.get("contestId")
         verdict = obj.get("verdict")
         points = obj.get("points")
+        source_code = obj.get("sourceBase64")
         return cls(
             identifier,
             creation_time_seconds,
@@ -675,6 +676,7 @@ class Submission(JSONDeserializable, Dictionaryable):
             contest_id,
             verdict,
             points,
+            base64.b64decode(source_code) if source_code else None,
         )
 
     def __init__(
@@ -692,6 +694,7 @@ class Submission(JSONDeserializable, Dictionaryable):
         contest_id=None,
         verdict=None,
         points=None,
+        source_code=None,
     ):
         self.id = identifier
         self.creation_time_seconds = creation_time_seconds
@@ -706,6 +709,7 @@ class Submission(JSONDeserializable, Dictionaryable):
         self.contest_id = contest_id
         self.verdict = verdict
         self.points = points
+        self.source_code = source_code
 
     def to_dict(self):
         return {
@@ -722,6 +726,7 @@ class Submission(JSONDeserializable, Dictionaryable):
             "contest_id": self.contest_id,
             "verdict": self.verdict,
             "points": self.points,
+            "source_code": self.source_code
         }
 
 

--- a/codeforces_api/types.py
+++ b/codeforces_api/types.py
@@ -676,7 +676,7 @@ class Submission(JSONDeserializable, Dictionaryable):
             contest_id,
             verdict,
             points,
-            base64.b64decode(source_code) if source_code else None,
+            base64.b64decode(source_code).decode() if source_code else None,
         )
 
     def __init__(


### PR DESCRIPTION
Pull request
============

Description
-----------

[User Status](https://codeforces.com/apiHelp/methods#user.status) also accepts the `includeSources` parameter, which will then return a `Submission` object with an additional `sourceBase64` field. This contains the `Base64`-encoded `Submission`. Note that this only works for your ***OWN*** account.

The documentation about failed requests might need to be changed, but I'm not sure about that.

Motivation and Context
----------------------

> Why is this change required? What problem does it solve?

I need to fetch the code I submitted :D

How Has This Been Tested
------------------------

Ran the function with and without `includeSources`.


Types of changes
----------------

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Checklist
---------

Go over all the following points, and put an `x` in all the boxes that apply.

If you're unsure about any of these, don't hesitate to ask. We're here to help!

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
